### PR TITLE
Adds the ability to set the generated class namespace

### DIFF
--- a/src/Steppify.php
+++ b/src/Steppify.php
@@ -58,6 +58,9 @@ class Steppify extends Command implements CustomCommandInterface {
 		$settings['namespace']    = '';
 		$settings['postfix']      = $postfix;
 		$settings['steps-config'] = $this->getStepsGenerationConfig($input);
+        if (0 < strlen($settings['steps-config']['namespace'])) {
+            $settings['namespace'] = $settings['steps-config']['namespace'];
+        }
 
 		$generator = new GherkinSteps($module, $settings);
 


### PR DESCRIPTION
Thanks for a great project!  :+1: 

Not sure if this is the best way to go about this - but I couldn't see a way to actually set the namespace for the generated steps file, and in my (Symfony 4) project running with codeception 3 (see https://github.com/lucatume/codeception-steppify/pull/5) the namespace needed to be App\Tests, so I added this to let me set it.
