### PR TITLE
Fix wp-browser step generation

### DIFF
--- a/src/Generator/GherkinSteps.php
+++ b/src/Generator/GherkinSteps.php
@@ -497,6 +497,8 @@ EOF;
                 $defaultValue = 'null';
             } elseif (is_string($defaultValue)) {
                 $defaultValue = "'" . $defaultValue . "'";
+            } elseif (is_bool($defaultValue)) {
+                $defaultValue = $defaultValue ? 'true' : 'false';
             }
 
             return sprintf('%s $%s = %s', $type, $name, $defaultValue);

--- a/src/Steppify.php
+++ b/src/Steppify.php
@@ -80,7 +80,7 @@ class Steppify extends Command implements CustomCommandInterface {
 
 		$file = $this->buildPath(Configuration::supportDir() . '_generated', $settings['name'], $settings['postfix'] );
 
-		return $this->createFile($file, $content, true);
+		return (int)$this->createFile($file, $content, true);
 	}
 
 	/**


### PR DESCRIPTION
This may also solve #4? The Repository I was generating these for has Codeception 4.2.2 installed. 

I was attempting to generate a Trait full of Steps for wp-browser and noticed these issues. Figured I'd push up a quick PR :) 

Note: This does still require a configuration file as `amOnAdminPage` will otherwise generate the same Step text as `amOnPage`. I haven't quite figured out what has caused those to result in the same Step text. 

```yml
modules:
  \Codeception\Module\WPBrowser:
    methods:
      amOnAdminPage:
        generates: [given]
        step:
          - I am on admin page :page
```